### PR TITLE
Use threads instead of onframe callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ You can scale the `OVR Root` empty to fix most scale issues. Location and Rotati
 
 ## Usage
 
-You can press the space bar to start streaming data from OpenVR. If Auto Keying is on, it will start inserting keyframes for the target (opaque) models. It doesn't use any fancy keying or NLA features, it simply (over)writes the transformations.
+You can press the `Start Recording` button to start writing keyframes to the object. It will clear the existing ones for the current action!
+
+The data is recorded in sub-frames and won't necessarily match your framerate. It is saved as fast as OpenVR provides it. The viewport will max out at 60fps, but the data is recorded and applied at OpenVR's precision.
+
+When you press the space bar, the realtime tracking will temporarily pause and the recorded take will play.
+
+It is encouraged to save each successful take to an NLA track, so it doesn't get overwritten.
 
 ## Troubleshooting
 
@@ -83,8 +89,6 @@ If in doubt, open up the console window with `Window > Toggle System Console` an
 
 **If your steam installation is in a different directory than `C:/Program Files (x86)/Steam/steamapps/common/SteamVR`, you will need to go into the source code and correct the path at the top.** I will try to put this in the settings menu eventually.
 
-If the tracking is coming out weird, your scene may be too complicated to run at realtime. Try using the `Simplfy` options in the `Render Properties` panel.
-
 ## Probably Common Questions
 
 Q: Can I offset location and rotation?
@@ -95,9 +99,9 @@ Q: Will other controller models show besides the generic HMD, OG Vive Controller
 
 A: Not currently. This may be implemented in the future.
 
-Q: Can I record data at a different frame rate than my scene?
+Q: Will my scene animations play during recording?
 
-A: No. This is a limitation of Blender's API. It is difficult to run a continuous process without freezing up the interface. A solution is being sought after.
+A: No. That may change in the future if needed.
 
 ## Credits
 **Huge** credits to [shteeve](https://blenderartists.org/u/shteeve) and [toyxyz](https://blenderartists.org/u/toyxyz) at [blenderartists.org](https://blenderartists.org/) for the [research and basis of this extension](https://blenderartists.org/t/openvr-tracker-streaming/1236428).

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "blender_openvr"
-version = "1.0.0"
+version = "1.1.0"
 name = "Blender OpenVR"
 tagline = "Use OpenVR trackers and devices directly in Blender"
 maintainer = "Ethan Porcaro <ethan@varrett.com>"

--- a/blender_openvr/properties.py
+++ b/blender_openvr/properties.py
@@ -28,8 +28,11 @@ class OVRTracker(bpy.types.PropertyGroup):
 class OVRContext(bpy.types.PropertyGroup):
     enabled: bpy.props.BoolProperty(name="OpenVR active", default=False)
     calibration_stage: bpy.props.IntProperty(name="Stage number of OpenVR Calibration", default=0)
+    recording: bpy.props.BoolProperty(name="OpenVR recording", default=False)
 
     trackers: bpy.props.CollectionProperty(type=OVRTracker)
     selected_tracker: bpy.props.IntProperty(name="Selected tracker", default=0)
 
     offset: bpy.props.PointerProperty(type=OVRTransform, name="Tracker offset")
+
+    record_start_frame: bpy.props.IntProperty(name="Recording start frame", default=0)

--- a/blender_openvr/tracking.py
+++ b/blender_openvr/tracking.py
@@ -1,9 +1,198 @@
+import datetime
+import queue
+import threading
+from typing import Generator
+
 import bpy
 import bpy_extras
 import openvr
 from mathutils import Matrix
 
-from .properties import OVRContext
+from .properties import OVRContext, OVRTracker
+
+# Shared variables
+
+pose_queue = queue.Queue()
+polling_thread = None
+stop_thread_flag = threading.Event()
+
+data_buffer = []
+buffer_lock = threading.Lock()
+
+
+def _get_poses(ovr_context: OVRContext) -> Generator[tuple[datetime.datetime, OVRTracker, Matrix], None, None]:
+    system = openvr.VRSystem()
+    poses, _ = openvr.VRCompositor().waitGetPoses([], None)
+    time = datetime.datetime.now()
+
+    for tracker in ovr_context.trackers:
+        if not bool(system.isTrackedDeviceConnected(tracker.index)):
+            continue
+
+        absolute_pose = poses[tracker.index].mDeviceToAbsoluteTracking
+
+        mat = Matrix([list(absolute_pose[0]), list(absolute_pose[1]), list(absolute_pose[2]), [0, 0, 0, 1]])
+        mat_world = bpy_extras.io_utils.axis_conversion("Z", "Y", "Y", "Z").to_4x4()
+        mat_world = mat_world @ mat
+
+        # Apply scale
+        root = bpy.data.objects.get("OVR Root")
+        if root:
+            mat_world.translation = mat_world.translation * (root.scale * 2)
+            mat_world = mat_world @ Matrix.Scale(root.scale.length, 4)
+
+        yield time, tracker, mat_world
+
+
+def _openvr_poll_thread_func(ovr_context: OVRContext):
+    global pose_queue, stop_thread_flag, data_buffer, buffer_lock
+
+    while not stop_thread_flag.is_set():
+        pose_chunk = []
+        for pose_data in _get_poses(ovr_context):
+            pose_chunk.append(pose_data)
+
+        with buffer_lock:
+            data_buffer.append(pose_chunk)
+
+
+def _clear_buffer():
+    global data_buffer, buffer_lock
+    with buffer_lock:
+        data_buffer.clear()
+
+
+def _get_buffer() -> list[list[tuple[datetime.datetime, OVRTracker, Matrix]]]:
+    global data_buffer, buffer_lock
+
+    with buffer_lock:
+        buffer_copy = data_buffer.copy()
+
+    return buffer_copy
+
+
+def _get_latest_poses() -> list[tuple[datetime.datetime, OVRTracker, Matrix]] | None:
+    global data_buffer, buffer_lock
+    with buffer_lock:
+        if len(data_buffer) == 0:
+            return None
+
+    return data_buffer[-1]
+
+
+def _apply_poses():
+    # Don't preview when playing, since a previous recording may interfere
+    if bpy.context.screen.is_animation_playing:
+        return
+
+    pose_data = _get_latest_poses()
+    if not pose_data:
+        return
+
+    for time, tracker, pose in pose_data:
+        tracker_obj = bpy.data.objects.get(tracker.name)
+        if not tracker_obj:
+            continue
+
+        tracker_obj.matrix_world = pose
+
+
+def _pose_vis_timer():
+    _apply_poses()
+    return 1.0 / 60  # 60hz
+
+
+def _insert_action(ovr_context: OVRContext):
+    pose_data = _get_buffer()
+    num_samples = len(pose_data)
+    print(f"OpenVR Processing {num_samples} recorded samples")
+
+    if num_samples == 0:
+        return
+
+    # Frame and conversion math
+    take_start_time = pose_data[0][0][0]
+    framerate = bpy.context.scene.render.fps / bpy.context.scene.render.fps_base
+    start_frame = ovr_context.record_start_frame
+
+    # Clear previous frames, since we record in sub-frames and some may linger from last run
+    for tracker in ovr_context.trackers:
+        tracker_obj = bpy.data.objects.get(tracker.name)
+        if tracker_obj.animation_data is None:
+            continue
+
+        action = tracker_obj.animation_data.action
+        if not action:
+            continue
+
+        for curve in action.fcurves:
+            action.fcurves.remove(curve)
+
+    # Add new frames
+    for sample in pose_data:
+        for time, tracker, pose in sample:
+            # Get object for tracker
+            tracker_obj = bpy.data.objects.get(tracker.name)
+            if not tracker_obj:
+                continue
+
+            # Create animation data if it doesn't exist
+            if tracker_obj.animation_data is None:
+                tracker_obj.animation_data_create()
+
+            # Add frames (using subframe)
+            time_delta = time - take_start_time
+            frame = start_frame + time_delta.total_seconds() * framerate
+
+            tracker_obj.matrix_world = pose
+            tracker_obj.keyframe_insert("location", frame=frame)
+            tracker_obj.keyframe_insert("rotation_euler", frame=frame)
+            tracker_obj.keyframe_insert("scale", frame=frame)
+
+
+def start_recording():
+    _clear_buffer()
+
+    print("OpenVR Recording Started")
+
+
+def stop_recording(ovr_context: OVRContext | None):
+    stop_preview()
+    _insert_action(ovr_context)
+    _clear_buffer()
+    start_preview(ovr_context)
+
+    print("OpenVR Recording Stopped")
+
+
+def start_preview(ovr_context: OVRContext):
+    global polling_thread, stop_thread_flag, data_buffer, buffer_lock
+
+    stop_thread_flag.clear()
+    polling_thread = threading.Thread(target=lambda: _openvr_poll_thread_func(ovr_context))
+    polling_thread.daemon = True  # Quit with Blender
+    polling_thread.start()
+
+    if not bpy.app.timers.is_registered(_pose_vis_timer):
+        bpy.app.timers.register(_pose_vis_timer)
+
+    print("OpenVR Preview Started")
+
+
+def stop_preview():
+    global polling_thread, stop_thread_flag
+
+    if bpy.app.timers.is_registered(_pose_vis_timer):
+        bpy.app.timers.unregister(_pose_vis_timer)
+
+    if polling_thread and polling_thread.is_alive():
+        stop_thread_flag.set()
+        polling_thread.join(timeout=1.0)
+
+    polling_thread = None
+    stop_thread_flag.clear()
+
+    print("OpenVR Preview Stopped")
 
 
 def load_trackers(ovr_context: OVRContext, reset=False):
@@ -31,40 +220,3 @@ def load_trackers(ovr_context: OVRContext, reset=False):
 
         tracker.index = i  # Just in case, do it for both existing and non-existing
         tracker.connected = bool(system.isTrackedDeviceConnected(i))
-
-
-def track_trackers(ovr_context: OVRContext):
-    system = openvr.VRSystem()
-    poses, _ = openvr.VRCompositor().waitGetPoses([], None)
-
-    for tracker in ovr_context.trackers:
-        tracker.connected = bool(system.isTrackedDeviceConnected(tracker.index))
-        if not tracker.connected:
-            continue
-
-        absolute_pose = poses[tracker.index].mDeviceToAbsoluteTracking
-
-        mat = Matrix([list(absolute_pose[0]), list(absolute_pose[1]), list(absolute_pose[2]), [0, 0, 0, 1]])
-        mat_world = bpy_extras.io_utils.axis_conversion("Z", "Y", "Y", "Z").to_4x4()
-        mat_world = mat_world @ mat
-
-        # Apply scale
-        root = bpy.data.objects.get("OVR Root")
-        if root:
-            mat_world.translation = mat_world.translation * (root.scale * 2)
-            mat_world = mat_world @ Matrix.Scale(root.scale.length, 4)
-
-        # Apply
-        tracker_obj = bpy.data.objects.get(tracker.name)
-
-        # If it doesn't exist, resync the trackers.
-        if not tracker_obj:
-            load_trackers(ovr_context)
-            continue  # We'll catch it next time around
-
-        tracker_obj.matrix_world = mat_world
-
-        if bpy.context.scene.tool_settings.use_keyframe_insert_auto:
-            tracker_obj.keyframe_insert("location")
-            tracker_obj.keyframe_insert("rotation_euler")
-            tracker_obj.keyframe_insert("scale")

--- a/blender_openvr/ui.py
+++ b/blender_openvr/ui.py
@@ -6,7 +6,8 @@ from .operators import (
     ToggleCalibrationOperator,
     ReloadTrackersOperator,
     ResetTrackersOperator,
-    CreateRefsOperator
+    CreateRefsOperator,
+    ToggleRecordOperator
 )
 from .properties import OVRContext
 
@@ -89,3 +90,23 @@ class OpenVRPanel(View3DPanel, bpy.types.Panel):
         # Reset names button
         layout.operator_context = "INVOKE_DEFAULT"
         layout.operator(ResetTrackersOperator.bl_idname, text="Trim And Reset All Trackers And Names")
+
+        # Recording
+        layout.label(text="Recording")
+
+        start_record_label = "Start Recording"
+        stop_record_label = "Stop Recording"
+        active_record_label = stop_record_label if ovr_context.recording else start_record_label
+
+        start_record_icon = "RECORD_OFF"
+        stop_record_icon = "RECORD_ON"
+        active_record_icon = stop_record_icon if ovr_context.recording else start_record_icon
+
+        # I hate warnings (for icon type checking)
+        # noinspection PyTypeChecker
+        layout.operator(
+            ToggleRecordOperator.bl_idname,
+            text=active_record_label,
+            icon=active_record_icon,
+            depress=ovr_context.recording
+        )


### PR DESCRIPTION
Now uses threads and buffers to record at realtime. Tracking info is stored at full precision to a buffer, and the scene updates with the latest data at 60hz for visualization. Bumped version to 1.1.0 in preparation for the next release.